### PR TITLE
Handle project changes from the server

### DIFF
--- a/LSP-lua.sublime-settings
+++ b/LSP-lua.sublime-settings
@@ -11,6 +11,13 @@
         "${storage_path}/LSP-lua/main.lua"
     ],
 
+    // Initialization options sent to the subprocess during startup. You should
+    // normally not touch this.
+    "initializationOptions": {
+        // We understand how to handle configuration changes from the server.
+        "changeConfiguration": true
+    },
+
     // The server version to download in $CACHE/Package Storage
     "server_version": "2.3.6",
 


### PR DESCRIPTION
This handles the custom $/command notification from the server and stores
the settings in the project_data() of the Window. If the project data is not
backed by a .sublime-project, then a dialog will appear that tells the user
to save the project, otherwise the changes are lost the next time the folder
is opened.

Fixes #23
Fixes #20