### PR TITLE
Add SemanticEnhanced value to the "Lua.color.mode" setting

### DIFF
--- a/LSP-lua.sublime-settings
+++ b/LSP-lua.sublime-settings
@@ -36,7 +36,7 @@
     // The server-specific settings
     "settings": {
         // Color mode.
-        // possible values: Grammar, Semantic
+        // possible values: Grammar, Semantic, SemanticEnhanced
         "Lua.color.mode": "Grammar",
         // When the input looks like a file name, automatically `require` this file.
         "Lua.completion.autoRequire": true,

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -22,15 +22,17 @@
                   "additionalProperties": false,
                   "properties": {
                     "Lua.color.mode": {
-                      "default": "Semantic",
+                      "default": "Grammar",
                       "enum": [
                         "Grammar",
-                        "Semantic"
+                        "Semantic",
+                        "SemanticEnhanced"
                       ],
                       "markdownDescription": "Color mode.",
                       "markdownEnumDescriptions": [
                         "Grammar color.",
-                        "Semantic color. You may need to set `editor.semanticHighlighting.enabled` to `true` to take effect."
+                        "Semantic color.",
+                        "Enhanced semantic color. Like `Semantic`, but with additional analysis which might be more computationally expensive."
                       ],
                       "type": "string"
                     },


### PR DESCRIPTION
When trying https://github.com/sublimelsp/LSP-lua/pull/28 I've realized that the server supports this new value also.

Might depend on the updated server version from https://github.com/sublimelsp/LSP-lua/pull/28.