### PR TITLE
Add missing commas in sublime-package.json

### DIFF
--- a/sublime-package.json
+++ b/sublime-package.json
@@ -3019,7 +3019,7 @@
                         "Apply",
                         "ApplyInMemory",
                         "Disable"
-                      ]
+                      ],
                       "markdownDescription": "Automatic detection and adaptation of third-party libraries, currently supported libraries are:\n\n* OpenResty\n* Cocos4.0\n* L\u00d6VE\n* L\u00d6VR\n* skynet\n* Jass\n",
                       "markdownEnumDescriptions": [
                         "TODO: Needs documentation",
@@ -3028,7 +3028,7 @@
                         "TODO: Needs documentation",
                         "TODO: Needs documentation",
                         "TODO: Needs documentation"
-                      ]
+                      ],
                       "type": [
                         "boolean",
                         "string"


### PR DESCRIPTION
Missing commas resulted in parsing error when loading the plugin. 
![image](https://github.com/sublimelsp/LSP-lua/assets/95593553/f92b4b96-0cb0-4425-9277-af0cb60b1bee)

After removing the plugin, installed the plugin manually with the corrections and it worked.

Win10, Build 4169